### PR TITLE
Use dependencies from vendor directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/hal-browser-${upstream.version}" excludes="vendor/" />
+                                    <fileset dir="${project.build.directory}/hal-browser-${upstream.version}" />
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
The original project is set up in a very straightforward way, ignoring any dependency management solution available, which might make sense from the maintainer’s perspective.

Considering the use case for including the hal-browser as a WebJar, the easiest solution is to put the vendor directory back. This should not interfere with actual jQuery or Bootstrap WebJars that might be included and allows the browser to work out of the box for now.
